### PR TITLE
Return angles in order of application and add more tests.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,10 +6,18 @@ on:
 jobs:
   build_and_test:
     name: Build and test
-    runs-on: fizyr
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@master
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -25,8 +33,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace --all-targets --all-features
-      - name: Cleanup
-        uses: actions-rs/cargo@v1
-        with:
-          command: sweep
-          args: --maxsize 5120 -r

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,9 @@ name = "angle-conversion"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "assert2",
+ "nalgebra",
+ "rand",
 ]
 
 [[package]]
@@ -19,10 +22,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert2"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1b167af16149cd41ff2b784bf511bb4208b21c3b05f3f61e30823ce3986361"
+dependencies = [
+ "assert2-macros",
+ "atty",
+ "yansi",
+]
+
+[[package]]
+name = "assert2-macros"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ac27dd1c8f16b282d1c22a8a5ae17119acc757101dec79054458fef62c447e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bytemuck"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a89248335f688e4bd994e6d030fd7e185eb41769b8c435395075425e100ac6"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -32,3 +173,173 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+
+[[package]]
+name = "simba"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a2609e876d4f77f6ab7ff5254fc39b4f1927ba8e6db3d18be7c32534d3725e"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3aba2d1dac31ac7cae82847ac5b8be822aee8f99a4e100f279605016b185c5f"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ publish = ["fizyr"]
 
 [dev-dependencies]
 approx = "0.5.1"
+assert2 = "0.3.6"
+nalgebra = "0.31.0"
+rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@
 
 
 mod math;
+
+#[cfg(test)]
 mod tests;
 
 use math::{sqrt, sin, cos, atan2, asin, clamp};

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn convert_axis_angle_to_euler_yxz(rx: f64, ry: f64, rz: f64, angle: f64) -> (f6
 	let euler_y = atan2(2.0 * (qx * qz + qw * qy), 1.0 - 2.0 * (qx * qx + qy * qy));
 	let euler_z = atan2(2.0 * (qx * qy + qw * qz), 1.0 - 2.0 * (qx * qx + qz * qz));
 
-	return (euler_x, euler_y, euler_z);
+	return (euler_y, euler_x, euler_z);
 }
 
 /// Convert from AxisAngle to Euler ZXY.
@@ -96,7 +96,7 @@ fn convert_axis_angle_to_euler_zxy(rx: f64, ry: f64, rz: f64, angle: f64) -> (f6
 	let euler_y = atan2(2.0 * (qw * qy - qx * qz), 1.0 - 2.0 * (qx * qx + qy * qy));
 	let euler_z = atan2(2.0 * (qw * qz - qx * qy), 1.0 - 2.0 * (qx * qx + qz * qz));
 
-	return (euler_x, euler_y, euler_z);
+	return (euler_z, euler_x, euler_y);
 }
 
 /// Convert from AxisAngle to Euler ZYX.
@@ -128,7 +128,7 @@ fn convert_axis_angle_to_euler_zyx(rx: f64, ry: f64, rz: f64, angle: f64) -> (f6
 	let euler_y = asin(clamp(2.0 * (qw * qy - qx * qz), -1.0, 1.0));
 	let euler_z = atan2(2.0 * (qx * qy + qw * qz), 1.0 - 2.0 * (qy * qy + qz * qz));
 
-	return (euler_x, euler_y, euler_z);
+	return (euler_z, euler_y, euler_x);
 }
 
 /// Convert from AxisAngle to Euler YZX.
@@ -157,7 +157,7 @@ fn convert_axis_angle_to_euler_yzx(rx: f64, ry: f64, rz: f64, angle: f64) -> (f6
 	let euler_y = atan2(2.0 * (qw * qy - qx * qz), 1.0 - 2.0 * (qy * qy + qz * qz));
 	let euler_z = asin(clamp(2.0 * (qx * qy + qw * qz), -1.0, 1.0));
 
-	return (euler_x, euler_y, euler_z);
+	return (euler_y, euler_z, euler_x);
 }
 
 /// Convert from AxisAngle to Euler XZY.
@@ -186,7 +186,7 @@ fn convert_axis_angle_to_euler_xzy(rx: f64, ry: f64, rz: f64, angle: f64) -> (f6
 	let euler_y = atan2(2.0 * (qx * qz + qw * qy), 1.0 - 2.0 * (qy * qy + qz * qz));
 	let euler_z = asin(clamp(2.0 * (qw * qz - qx * qy), -1.0, 1.0));
 
-	return (euler_x, euler_y, euler_z);
+	return (euler_x, euler_z, euler_y);
 }
 
 
@@ -205,32 +205,32 @@ fn main() {
 	println!("Euler (deg) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_ry.to_degrees(), euler_rz.to_degrees());
 	println!("---");
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_yxz(rx, ry, rz, angle);
+	let (euler_ry, euler_rx, euler_rz) = convert_axis_angle_to_euler_yxz(rx, ry, rz, angle);
 	let order = "yxz";
-	println!("Euler (rad) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx, euler_ry, euler_rz);
-	println!("Euler (deg) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_ry.to_degrees(), euler_rz.to_degrees());
+	println!("Euler (rad) {}: (ry: {}, rx: {}, rz: {})", order.to_uppercase(), euler_ry, euler_rx, euler_rz);
+	println!("Euler (deg) {}: (ry: {}, rx: {}, rz: {})", order.to_uppercase(), euler_ry.to_degrees(), euler_rx.to_degrees(), euler_rz.to_degrees());
 	println!("---");
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_zxy(rx, ry, rz, angle);
+	let (euler_rz, euler_rx, euler_ry) = convert_axis_angle_to_euler_zxy(rx, ry, rz, angle);
 	let order = "zxy";
-	println!("Euler (rad) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx, euler_ry, euler_rz);
-	println!("Euler (deg) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_ry.to_degrees(), euler_rz.to_degrees());
+	println!("Euler (rad) {}: (rz: {}, rx: {}, ry: {})", order.to_uppercase(), euler_rz, euler_rx, euler_ry);
+	println!("Euler (deg) {}: (rz: {}, rx: {}, ry: {})", order.to_uppercase(), euler_rz.to_degrees(), euler_rx.to_degrees(), euler_ry.to_degrees());
 	println!("---");
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_zyx(rx, ry, rz, angle);
+	let (euler_rz, euler_ry, euler_rx) = convert_axis_angle_to_euler_zyx(rx, ry, rz, angle);
 	let order = "zyx";
-	println!("Euler (rad) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx, euler_ry, euler_rz);
-	println!("Euler (deg) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_ry.to_degrees(), euler_rz.to_degrees());
+	println!("Euler (rad) {}: (rz: {}, ry: {}, rx: {})", order.to_uppercase(), euler_rz, euler_ry, euler_rx);
+	println!("Euler (deg) {}: (rz: {}, ry: {}, rx: {})", order.to_uppercase(), euler_rz.to_degrees(), euler_ry.to_degrees(), euler_rx.to_degrees());
 	println!("---");
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_yzx(rx, ry, rz, angle);
+	let (euler_ry, euler_rz, euler_rx) = convert_axis_angle_to_euler_yzx(rx, ry, rz, angle);
 	let order = "yzx";
-	println!("Euler (rad) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx, euler_ry, euler_rz);
-	println!("Euler (deg) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_ry.to_degrees(), euler_rz.to_degrees());
+	println!("Euler (rad) {}: (ry: {}, rz: {}, rx: {})", order.to_uppercase(), euler_ry, euler_rz, euler_rx);
+	println!("Euler (deg) {}: (ry: {}, rz: {}, rx: {})", order.to_uppercase(), euler_ry.to_degrees(), euler_rz.to_degrees(), euler_rx.to_degrees());
 	println!("---");
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_xzy(rx, ry, rz, angle);
+	let (euler_rx, euler_rz, euler_ry) = convert_axis_angle_to_euler_xzy(rx, ry, rz, angle);
 	let order = "xzy";
-	println!("Euler (rad) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx, euler_ry, euler_rz);
-	println!("Euler (deg) {}: (rx: {}, ry: {}, rz: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_ry.to_degrees(), euler_rz.to_degrees());
+	println!("Euler (rad) {}: (rx: {}, rz: {}, ry: {})", order.to_uppercase(), euler_rx, euler_rz, euler_ry);
+	println!("Euler (deg) {}: (rx: {}, rz: {}, ry: {})", order.to_uppercase(), euler_rx.to_degrees(), euler_rz.to_degrees(), euler_ry.to_degrees());
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,15 +1,17 @@
+use approx::assert_relative_eq;
+use nalgebra as na;
+
+use crate::{
+	convert_axis_angle_to_euler_xyz,
+	convert_axis_angle_to_euler_yxz,
+	convert_axis_angle_to_euler_zxy,
+	convert_axis_angle_to_euler_zyx,
+	convert_axis_angle_to_euler_yzx,
+	convert_axis_angle_to_euler_xzy
+};
+
 #[test]
 fn test_convert_axis_angle_to_euler() {
-	use approx::assert_relative_eq;
-
-	use crate::{
-		convert_axis_angle_to_euler_xyz,
-		convert_axis_angle_to_euler_yxz,
-		convert_axis_angle_to_euler_zxy,
-		convert_axis_angle_to_euler_zyx,
-		convert_axis_angle_to_euler_yzx,
-		convert_axis_angle_to_euler_xzy
-	};
 
 	// Using random values (vector is normalized).
 	let rx = 0.35000955;
@@ -48,4 +50,108 @@ fn test_convert_axis_angle_to_euler() {
 	assert_relative_eq!(euler_rx, 0.1092933, epsilon = 1e-6);
 	assert_relative_eq!(euler_rz, 0.1448436, epsilon = 1e-6);
 	assert_relative_eq!(euler_ry, 0.2057181, epsilon = 1e-6);
+}
+
+fn rand(random: &mut impl rand::Rng, min: f64, max: f64) -> f64 {
+	use rand::distributions::Distribution;
+
+	let dist = rand::distributions::Uniform::new(min, max);
+	dist.sample(random)
+}
+
+fn rotation(axis_x: f64, axis_y: f64, axis_z: f64, angle: f64) -> na::UnitQuaternion<f64> {
+	let axis = na::Vector3::new(axis_x, axis_y, axis_z);
+	let axis = na::UnitVector3::new_normalize(axis);
+	na::UnitQuaternion::from_axis_angle(&axis, angle)
+}
+
+fn rot_x(angle: f64) -> na::UnitQuaternion<f64> {
+	rotation(1.0, 0.0, 0.0, angle)
+}
+
+fn rot_y(angle: f64) -> na::UnitQuaternion<f64> {
+	rotation(0.0, 1.0, 0.0, angle)
+}
+
+fn rot_z(angle: f64) -> na::UnitQuaternion<f64> {
+	rotation(0.0, 0.0, 1.0, angle)
+}
+
+macro_rules! assert_vec {
+	($vec_a:expr, $vec_b: expr, $epsilon:expr) => {
+		{
+			let vec_a: nalgebra::Vector<_, _, _> = $vec_a;
+			let vec_b: nalgebra::Vector<_, _, _> = $vec_b;
+			let distance = (vec_a - vec_b).norm();
+			let epsilon = $epsilon;
+			if distance > epsilon {
+				::assert2::assert!($vec_a == $vec_b, "distance ({distance}) > epsilon ({epsilon})")
+			}
+		}
+	}
+}
+
+fn random_samples() -> impl Iterator<Item = (f64, f64, f64, f64)> {
+	let mut random: rand::rngs::StdRng = rand::SeedableRng::seed_from_u64(0);
+	(0..1_000).into_iter().map(move |_| {
+		let axis_x = rand(&mut random, 0.0, 1.0);
+		let axis_y = rand(&mut random, 0.0, 1.0);
+		let axis_z = rand(&mut random, 0.0, 1.0);
+		let angle = rand(&mut random, 0.0, std::f64::consts::TAU);
+		(axis_x, axis_y, axis_z, angle)
+	})
+}
+
+#[test]
+fn test_random_xyz() {
+	for (axis_x, axis_y, axis_z, angle) in random_samples() {
+		let rotation = rotation(axis_x, axis_y, axis_z, angle);
+		let (rx, ry, rz) = convert_axis_angle_to_euler_xyz(axis_x, axis_y, axis_z, angle);
+		assert_vec!((rot_x(rx) * rot_y(ry) * rot_z(rz)).scaled_axis(), rotation.scaled_axis(), 1e-10);
+	}
+}
+
+#[test]
+fn test_random_yxz() {
+	for (axis_x, axis_y, axis_z, angle) in random_samples() {
+		let rotation = rotation(axis_x, axis_y, axis_z, angle);
+		let (ry, rx, rz) = convert_axis_angle_to_euler_yxz(axis_x, axis_y, axis_z, angle);
+		assert_vec!((rot_y(ry) * rot_x(rx) * rot_z(rz)).scaled_axis(), rotation.scaled_axis(), 1e-10);
+	}
+}
+
+#[test]
+fn test_random_zxy() {
+	for (axis_x, axis_y, axis_z, angle) in random_samples() {
+		let rotation = rotation(axis_x, axis_y, axis_z, angle);
+		let (rz, rx, ry) = convert_axis_angle_to_euler_zxy(axis_x, axis_y, axis_z, angle);
+		assert_vec!((rot_z(rz) * rot_x(rx) * rot_y(ry)).scaled_axis(), rotation.scaled_axis(), 1e-10);
+	}
+}
+
+#[test]
+fn test_random_zyx() {
+	for (axis_x, axis_y, axis_z, angle) in random_samples() {
+		let rotation = rotation(axis_x, axis_y, axis_z, angle);
+		let (rz, ry, rx) = convert_axis_angle_to_euler_zyx(axis_x, axis_y, axis_z, angle);
+		assert_vec!((rot_z(rz) * rot_y(ry) * rot_x(rx)).scaled_axis(), rotation.scaled_axis(), 1e-10);
+	}
+}
+
+#[test]
+fn test_random_yzx() {
+	for (axis_x, axis_y, axis_z, angle) in random_samples() {
+		let rotation = rotation(axis_x, axis_y, axis_z, angle);
+		let (ry, rz, rx) = convert_axis_angle_to_euler_yzx(axis_x, axis_y, axis_z, angle);
+		assert_vec!((rot_y(ry) * rot_z(rz) * rot_x(rx)).scaled_axis(), rotation.scaled_axis(), 1e-10);
+	}
+}
+
+#[test]
+fn test_random_xzy() {
+	for (axis_x, axis_y, axis_z, angle) in random_samples() {
+		let rotation = rotation(axis_x, axis_y, axis_z, angle);
+		let (rx, rz, ry) = convert_axis_angle_to_euler_xzy(axis_x, axis_y, axis_z, angle);
+		assert_vec!((rot_x(rx) * rot_z(rz) * rot_y(ry)).scaled_axis(), rotation.scaled_axis(), 1e-10);
+	}
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,28 +24,28 @@ fn test_convert_axis_angle_to_euler() {
 	assert_relative_eq!(euler_ry, 0.2035335, epsilon = 1e-6);
 	assert_relative_eq!(euler_rz, 0.1479187, epsilon = 1e-6);
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_yxz(rx, ry, rz, angle);
-	assert_relative_eq!(euler_rx, 0.0775457, epsilon = 1e-6);
+	let (euler_ry, euler_rx, euler_rz) = convert_axis_angle_to_euler_yxz(rx, ry, rz, angle);
 	assert_relative_eq!(euler_ry, 0.2041556, epsilon = 1e-6);
+	assert_relative_eq!(euler_rx, 0.0775457, epsilon = 1e-6);
 	assert_relative_eq!(euler_rz, 0.1639563, epsilon = 1e-6);
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_zxy(rx, ry, rz, angle);
+	let (euler_rz, euler_rx, euler_ry) = convert_axis_angle_to_euler_zxy(rx, ry, rz, angle);
+	assert_relative_eq!(euler_rz, 0.1457008, epsilon = 1e-6);
 	assert_relative_eq!(euler_rx, 0.1081443, epsilon = 1e-6);
 	assert_relative_eq!(euler_ry, 0.1898811, epsilon = 1e-6);
-	assert_relative_eq!(euler_rz, 0.1457008, epsilon = 1e-6);
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_zyx(rx, ry, rz, angle);
-	assert_relative_eq!(euler_rx, 0.1101078, epsilon = 1e-6);
-	assert_relative_eq!(euler_ry, 0.1887585, epsilon = 1e-6);
+	let (euler_rz, euler_ry, euler_rx) = convert_axis_angle_to_euler_zyx(rx, ry, rz, angle);
 	assert_relative_eq!(euler_rz, 0.1664424, epsilon = 1e-6);
+	assert_relative_eq!(euler_ry, 0.1887585, epsilon = 1e-6);
+	assert_relative_eq!(euler_rx, 0.1101078, epsilon = 1e-6);
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_yzx(rx, ry, rz, angle);
-	assert_relative_eq!(euler_rx, 0.0785954, epsilon = 1e-6);
+	let (euler_ry, euler_rz, euler_rx) = convert_axis_angle_to_euler_yzx(rx, ry, rz, angle);
 	assert_relative_eq!(euler_ry, 0.1913399, epsilon = 1e-6);
 	assert_relative_eq!(euler_rz, 0.1634591, epsilon = 1e-6);
+	assert_relative_eq!(euler_rx, 0.0785954, epsilon = 1e-6);
 
-	let (euler_rx, euler_ry, euler_rz) = convert_axis_angle_to_euler_xzy(rx, ry, rz, angle);
+	let (euler_rx, euler_rz, euler_ry) = convert_axis_angle_to_euler_xzy(rx, ry, rz, angle);
 	assert_relative_eq!(euler_rx, 0.1092933, epsilon = 1e-6);
-	assert_relative_eq!(euler_ry, 0.2057181, epsilon = 1e-6);
 	assert_relative_eq!(euler_rz, 0.1448436, epsilon = 1e-6);
+	assert_relative_eq!(euler_ry, 0.2057181, epsilon = 1e-6);
 }


### PR DESCRIPTION
This PR changes the returned angles to be in the order that they should be applied. This is quite important: when you have ZYX "Euler" angles, they are in the order ZYX. They are never ordered XYZ to be applied as ZYX.

Additionally, this PR adds a bunch of tests to verify the computation against nalgebra using randomly (but deterministically) generated input.

This PR will merge into the `initial-implementation` branch.